### PR TITLE
Suppor for MobilenetV2

### DIFF
--- a/receptive_field/python/util/parse_layer_parameters.py
+++ b/receptive_field/python/util/parse_layer_parameters.py
@@ -89,6 +89,8 @@ def _conv_kernel_size(node, name_to_node):
     weights_layer_param_name = weights_layer_read_name[:-5]
   elif weights_layer_read_name.endswith("/Conv2D/ReadVariableOp"):
     weights_layer_param_name = weights_layer_read_name[:-22] + "/kernel"
+  elif weights_layer_read_name.endswith("/depthwise/ReadVariableOp"):
+    weights_layer_param_name = weights_layer_read_name[:-25] + "/depthwise_kernel"
   else:
     raise ValueError(
         "Weight layer's name input to conv layer does not end with '/read' or "


### PR DESCRIPTION
Depthwise convolutionals have a kernel name "depthwise_kernel", while the other Conv2d have "kernel", that was why it was not working. Also the weight layer read name was different for these convolution as well. Added that line in order to support MobilenetV2.